### PR TITLE
Fix: corrigindo erro de digitação.

### DIFF
--- a/src/lsw-in.sh
+++ b/src/lsw-in.sh
@@ -34,7 +34,7 @@ depcheck () {
         else
             _packages+=("freerdp3-x11")
         fi
-        insta ca-certificates curl
+        install ca-certificates curl
         sudo install -m 0755 -d /etc/apt/keyrings
         sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
         sudo chmod a+r /etc/apt/keyrings/docker.asc


### PR DESCRIPTION
Este PR corrige um erro de digitação no script src/lsw-in.sh.
A linha responsável pela instalação de pacotes estava duplicando o comando instal (com apenas um “l”), o que quebrava a execução do script.

Alterações realizadas:

Corrigido instal → install

Mantida a instalação dos pacotes ca-certificates e curl de forma correta.

Motivação:

Garantir que o script rode corretamente sem falhas de sintaxe.

Melhorar a confiabilidade na configuração inicial do ambiente.